### PR TITLE
Added compatibility with Motion Smoothing

### DIFF
--- a/Code/Hooks/RendererHooks.cs
+++ b/Code/Hooks/RendererHooks.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Xna.Framework;
+﻿using Celeste.Mod.ExCameraDynamics.Code.Interop;
+using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Mono.Cecil.Cil;
 using Monocle;
@@ -65,11 +66,15 @@ namespace Celeste.Mod.ExCameraDynamics.Code.Hooks
 
             // Invoke the event
             OnBufferResize?.Invoke(BufferWidthOverride, BufferHeightOverride);
+
+			MotionSmoothingImports.ReloadLargeTextures?.Invoke();
         }
 
         public static void ResizeBufferToZoom(VirtualRenderTarget target)
         {
             if (target == null) return;
+
+			target = MotionSmoothingImports.GetResizableBuffer?.Invoke(target) ?? target;
 
             if (target.Width == BufferWidthOverride && target.Height == BufferHeightOverride) return; // don't resize what doesn't need to be resized.
 

--- a/Code/Interop/MotionSmoothingImports.cs
+++ b/Code/Interop/MotionSmoothingImports.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Net;
+using Microsoft.Xna.Framework;
+using Monocle;
+using MonoMod.ModInterop;
+
+namespace Celeste.Mod.ExCameraDynamics.Code.Interop;
+
+[ModImportName("MotionSmoothing")]
+public static class MotionSmoothingImports
+{
+    public static Func<VirtualRenderTarget, VirtualRenderTarget> GetResizableBuffer;
+
+	public static Action ReloadLargeTextures;
+}

--- a/Code/Module/ExCameraModule.cs
+++ b/Code/Module/ExCameraModule.cs
@@ -1,5 +1,6 @@
 using Celeste.Mod.ExCameraDynamics.Code.Entities;
 using Celeste.Mod.ExCameraDynamics.Code.Hooks;
+using Celeste.Mod.ExCameraDynamics.Code.Interop;
 using Celeste.Mod.ExCameraDynamics.Code.Module;
 using ExtendedCameraDynamics.Code.Backdrops;
 using MonoMod.ModInterop;
@@ -41,6 +42,7 @@ namespace Celeste.Mod.ExCameraDynamics
         public override void Load()
         {
             typeof(ExCameraInterop).ModInterop();
+			typeof(MotionSmoothingImports).ModInterop();
             On.Celeste.Level.LoadLevel += Level_LoadLevel;
             //Everest.Events.Level.OnLoadLevel += Level_OnLoadLevel;
             Everest.Events.Level.OnExit += Level_OnExit;

--- a/everest.yaml
+++ b/everest.yaml
@@ -4,3 +4,6 @@
   Dependencies:
     - Name: Everest
       Version: 1.5577.0
+  OptionalDependencies:
+    - Name: MotionSmoothing
+      Version: 1.3.2


### PR DESCRIPTION
This PR adds compatibility with Motion Smoothing v1.3.2+ (not yet published, but will be soon). When Motion Smoothing is loaded, ExCam checks with it to not accidentally resize its internal buffers, and also notifies it afterward.